### PR TITLE
Implement on-demand recursive circuit table loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,11 +600,13 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "evm_arithmetization",
  "plonky2",
  "proof_gen",
  "thiserror",
+ "trace_decoder",
  "tracing",
 ]
 
@@ -2736,18 +2738,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,3 +15,5 @@ proof_gen = { workspace = true }
 plonky2 = { workspace = true }
 evm_arithmetization = { workspace = true }
 clap = { workspace = true }
+anyhow = { workspace = true }
+trace_decoder = { workspace = true }

--- a/common/src/prover_state/circuit.rs
+++ b/common/src/prover_state/circuit.rs
@@ -11,7 +11,7 @@ use proof_gen::types::AllRecursiveCircuits;
 use crate::parsing::{parse_range, RangeParseError};
 
 /// Number of tables defined in plonky2.
-const NUM_TABLES: usize = 7;
+pub const NUM_TABLES: usize = 7;
 
 /// New type wrapper for [`Range`] that implements [`FromStr`] and [`Display`].
 ///
@@ -111,6 +111,19 @@ impl Circuit {
             Circuit::Memory => "memory",
         }
     }
+
+    /// Get the circuit name as a short str literal.
+    pub const fn as_short_str(&self) -> &'static str {
+        match self {
+            Circuit::Arithmetic => "a",
+            Circuit::BytePacking => "bp",
+            Circuit::Cpu => "c",
+            Circuit::Keccak => "k",
+            Circuit::KeccakSponge => "ks",
+            Circuit::Logic => "l",
+            Circuit::Memory => "m",
+        }
+    }
 }
 
 impl From<usize> for Circuit {
@@ -128,9 +141,25 @@ impl From<usize> for Circuit {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CircuitConfig {
     circuits: [Range<usize>; NUM_TABLES],
+}
+
+impl std::ops::Index<usize> for CircuitConfig {
+    type Output = Range<usize>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.circuits[index]
+    }
+}
+
+impl std::ops::Index<Circuit> for CircuitConfig {
+    type Output = Range<usize>;
+
+    fn index(&self, index: Circuit) -> &Self::Output {
+        &self.circuits[index as usize]
+    }
 }
 
 impl Default for CircuitConfig {
@@ -176,16 +205,8 @@ impl CircuitConfig {
     /// Get a unique string representation of the config.
     pub fn get_configuration_digest(&self) -> String {
         self.enumerate()
-            .map(|(circuit, range)| match circuit {
-                Circuit::Arithmetic => format!("a_{}-{}", range.start, range.end),
-                Circuit::BytePacking => format!("b_p_{}-{}", range.start, range.end),
-                Circuit::Cpu => format!("c_{}-{}", range.start, range.end),
-                Circuit::Keccak => format!("k_{}-{}", range.start, range.end),
-                Circuit::KeccakSponge => {
-                    format!("k_s_{}-{}", range.start, range.end)
-                }
-                Circuit::Logic => format!("l_{}-{}", range.start, range.end),
-                Circuit::Memory => format!("m_{}-{}", range.start, range.end),
+            .map(|(circuit, range)| {
+                format!("{}_{}-{}", circuit.as_short_str(), range.start, range.end)
             })
             .fold(String::new(), |mut acc, s| {
                 if !acc.is_empty() {

--- a/common/src/prover_state/circuit.rs
+++ b/common/src/prover_state/circuit.rs
@@ -11,7 +11,9 @@ use proof_gen::types::AllRecursiveCircuits;
 use crate::parsing::{parse_range, RangeParseError};
 
 /// Number of tables defined in plonky2.
-pub const NUM_TABLES: usize = 7;
+///
+/// TODO: This should be made public in the evm_arithmetization crate.
+pub(crate) const NUM_TABLES: usize = 7;
 
 /// New type wrapper for [`Range`] that implements [`FromStr`] and [`Display`].
 ///

--- a/common/src/prover_state/cli.rs
+++ b/common/src/prover_state/cli.rs
@@ -57,6 +57,8 @@ macro_rules! gen_prover_state_config {
         pub struct CliProverStateConfig {
             #[clap(long, help_heading = HEADING, default_value_t = CircuitPersistence::Disk)]
             pub persistence: CircuitPersistence,
+            #[clap(long, help_heading = HEADING, default_value_t = TableLoadStrategy::OnDemand)]
+            pub load_strategy: TableLoadStrategy,
 
             $(
                 #[clap(
@@ -102,13 +104,16 @@ impl CliProverStateConfig {
         config
     }
 
-    pub fn into_prover_state_manager(
-        self,
-        persistence: super::CircuitPersistence,
-    ) -> ProverStateManager {
+    pub fn into_prover_state_manager(self) -> ProverStateManager {
         ProverStateManager {
-            persistence,
+            persistence: self.persistence.with_load_strategy(self.load_strategy),
             circuit_config: self.into_circuit_config(),
         }
+    }
+}
+
+impl From<CliProverStateConfig> for ProverStateManager {
+    fn from(config: CliProverStateConfig) -> Self {
+        config.into_prover_state_manager()
     }
 }

--- a/common/src/prover_state/mod.rs
+++ b/common/src/prover_state/mod.rs
@@ -54,8 +54,8 @@ static P_STATE: OnceLock<ProverState> = OnceLock::new();
 ///
 /// Unlike the prover state, the prover state manager houses configuration and
 /// persistence information. This allows it to differentiate between the
-/// different transaction proof generation strategies. As such, generally only
-/// necessary when generating transaction proofs.
+/// different transaction proof generation strategies. As such, it is generally
+/// only necessary when generating transaction proofs.
 ///
 /// It's specified as a `OnceLock` for the same reasons as the prover state.
 static MANAGER: OnceLock<ProverStateManager> = OnceLock::new();

--- a/common/src/prover_state/mod.rs
+++ b/common/src/prover_state/mod.rs
@@ -2,22 +2,42 @@
 //!
 //! This module provides the following:
 //! - [`Circuit`] and [`CircuitConfig`] which can be used to dynamically
-//!   construct [`AllRecursiveCircuits`] from the specified circuit sizes.
+//!   construct [`evm_arithmetization::fixed_recursive_verifier::AllRecursiveCircuits`]
+//!   from the specified circuit sizes.
 //! - Command line arguments for constructing a [`CircuitConfig`].
 //!     - Provides default values for the circuit sizes.
 //!     - Allows the circuit sizes to be specified via environment variables.
-//! - Persistence utilities for saving and loading [`AllRecursiveCircuits`].
+//! - Persistence utilities for saving and loading
+//!   [`evm_arithmetization::fixed_recursive_verifier::AllRecursiveCircuits`].
 //! - Global prover state management via the [`P_STATE`] static and the
 //!   [`set_prover_state_from_config`] function.
-use std::{fmt::Display, sync::OnceLock};
+use std::sync::OnceLock;
 
-use clap::ValueEnum;
-use proof_gen::{prover_state::ProverState, VerifierState};
+use evm_arithmetization::{
+    fixed_recursive_verifier::RecursiveCircuitsForTableSize, proof::AllProof, prover::prove,
+    AllStark, StarkConfig,
+};
+use plonky2::{
+    field::goldilocks_field::GoldilocksField, plonk::config::PoseidonGoldilocksConfig,
+    util::timing::TimingTree,
+};
+use proof_gen::{proof_types::GeneratedTxnProof, prover_state::ProverState, VerifierState};
+use trace_decoder::types::TxnProofGenIR;
 use tracing::info;
+
+use self::circuit::{CircuitConfig, NUM_TABLES};
+use crate::prover_state::persistence::{
+    BaseProverResource, DiskResource, MonolithicProverResource, RecursiveCircuitResource,
+    VerifierResource,
+};
 
 pub mod circuit;
 pub mod cli;
 pub mod persistence;
+
+pub(crate) type Config = PoseidonGoldilocksConfig;
+pub(crate) type Field = GoldilocksField;
+pub(crate) const SIZE: usize = 2;
 
 /// The global prover state.
 ///
@@ -28,107 +48,263 @@ pub mod persistence;
 /// - This scheme works for both a cluster and a single machine. In particular,
 ///   whether imported from a worker node or a thread in the leader node
 ///   (in-memory mode), the prover state is initialized only once.
-pub static P_STATE: OnceLock<ProverState> = OnceLock::new();
+static P_STATE: OnceLock<ProverState> = OnceLock::new();
+
+/// The global prover state manager.
+///
+/// Unlike the prover state, the prover state manager houses configuration and
+/// persistence information. This allows it to differentiate between the
+/// different transaction proof generation strategies. As such, generally only
+/// necessary when generating transaction proofs.
+///
+/// It's specified as a `OnceLock` for the same reasons as the prover state.
+static MANAGER: OnceLock<ProverStateManager> = OnceLock::new();
+
+pub fn p_state() -> &'static ProverState {
+    P_STATE.get().expect("Prover state is not initialized")
+}
+
+pub fn p_manager() -> &'static ProverStateManager {
+    MANAGER
+        .get()
+        .expect("Prover state manager is not initialized")
+}
+
+/// Specifies how to load the table circuits.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum TableLoadStrategy {
+    #[default]
+    /// Load the circuit tables as needed for shrinking STARK proofs.
+    ///
+    /// - Generate a STARK proof.
+    /// - Compute the degree bits.
+    /// - Load the necessary table circuits.
+    OnDemand,
+    /// Load all the table circuits into a monolithic bundle.
+    Monolithic,
+}
 
 /// Specifies whether to persist the processed circuits.
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy)]
 pub enum CircuitPersistence {
     /// Do not persist the processed circuits.
     None,
     /// Persist the processed circuits to disk.
-    Disk,
+    Disk(TableLoadStrategy),
 }
 
-impl Display for CircuitPersistence {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CircuitPersistence::None => write!(f, "none"),
-            CircuitPersistence::Disk => write!(f, "disk"),
-        }
+impl Default for CircuitPersistence {
+    fn default() -> Self {
+        CircuitPersistence::Disk(TableLoadStrategy::default())
     }
 }
 
 /// Product of [`CircuitConfig`] and [`CircuitPersistence`].
-#[derive(Debug)]
-pub struct ProverStateConfig {
-    pub circuit_config: circuit::CircuitConfig,
+///
+/// Provides helper utilities for interacting with the prover state in
+/// accordance with the specified configuration and persistence strategy.
+#[derive(Default, Debug, Clone)]
+pub struct ProverStateManager {
+    pub circuit_config: CircuitConfig,
     pub persistence: CircuitPersistence,
 }
 
-/// Initializes the global prover state.
-pub fn set_prover_state_from_config(
-    ProverStateConfig {
-        circuit_config,
-        persistence,
-    }: ProverStateConfig,
-) -> Result<(), ProverState> {
-    info!("initializing prover state...");
-    let state = match persistence {
-        CircuitPersistence::None => {
-            info!("generating circuits...");
-            ProverState {
-                state: circuit_config.as_all_recursive_circuits(),
+impl ProverStateManager {
+    /// Load the table circuits necessary to shrink the STARK proof.
+    ///
+    /// [`AllProof`] provides the necessary degree bits for each circuit via the
+    /// [`AllProof::degree_bits`] method.
+    /// Using this information, for each circuit, a tuple is returned,
+    /// containing:
+    /// 1. The loaded table circuit at the specified size.
+    /// 2. An offset indicating the distance of the specified size relative to
+    ///    the configured range used to pre-process the circuits.
+    #[allow(clippy::type_complexity)]
+    fn load_table_circuits(
+        &self,
+        config: &StarkConfig,
+        all_proof: &AllProof<Field, Config, SIZE>,
+    ) -> anyhow::Result<[(RecursiveCircuitsForTableSize<Field, Config, SIZE>, u8); NUM_TABLES]>
+    {
+        let degrees = all_proof.degree_bits(config);
+
+        /// Given a recursive circuit index (e.g., Arithmetic / 0), return a
+        /// tuple containing the loaded table at the specified size and
+        /// its offset relative to the configured range used to pre-process the
+        /// circuits.
+        macro_rules! circuit {
+            ($circuit_index:expr) => {
+                (
+                    RecursiveCircuitResource::get(&(
+                        $circuit_index.into(),
+                        degrees[$circuit_index],
+                    ))
+                    .map_err(|e| {
+                        let circuit: $crate::prover_state::circuit::Circuit = $circuit_index.into();
+                        let size = degrees[$circuit_index];
+                        anyhow::Error::from(e).context(format!(
+                            "Attempting to load circuit: {circuit:?} at size: {size}"
+                        ))
+                    })?,
+                    (degrees[$circuit_index] - self.circuit_config[$circuit_index].start) as u8,
+                )
+            };
+        }
+
+        Ok([
+            circuit!(0),
+            circuit!(1),
+            circuit!(2),
+            circuit!(3),
+            circuit!(4),
+            circuit!(5),
+            circuit!(6),
+        ])
+    }
+
+    /// Generate a transaction proof using the specified input, loading the
+    /// circuit tables as needed to shrink the STARK proof.
+    fn txn_proof_on_demand(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
+        let config = StarkConfig::standard_fast_config();
+        let all_stark = AllStark::default();
+        let all_proof = prove(&all_stark, &config, input, &mut TimingTree::default(), None)?;
+
+        let table_circuits = self.load_table_circuits(&config, &all_proof)?;
+
+        let (intern, p_vals) =
+            p_state()
+                .state
+                .prove_root_after_initial_stark(all_proof, &table_circuits, None)?;
+
+        Ok(GeneratedTxnProof { intern, p_vals })
+    }
+
+    /// Generate a transaction proof using the specified input on the monolithic
+    /// circuit.
+    fn txn_proof_monolithic(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
+        let (intern, p_vals) = p_state().state.prove_root(
+            &AllStark::default(),
+            &StarkConfig::standard_fast_config(),
+            input,
+            &mut TimingTree::default(),
+            None,
+        )?;
+
+        Ok(GeneratedTxnProof { p_vals, intern })
+    }
+
+    /// Generate a transaction proof using the specified input.
+    ///
+    /// The specific implementation depends on the persistence strategy.
+    /// - If the persistence strategy is [`CircuitPersistence::None`] or
+    ///   [`CircuitPersistence::Disk`] with [`TableLoadStrategy::Monolithic`],
+    ///   the monolithic circuit is used.
+    /// - If the persistence strategy is [`CircuitPersistence::Disk`] with
+    ///   [`TableLoadStrategy::OnDemand`], the table circuits are loaded as
+    ///   needed.
+    pub fn generate_txn_proof(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
+        match self.persistence {
+            CircuitPersistence::None | CircuitPersistence::Disk(TableLoadStrategy::Monolithic) => {
+                info!("using monolithic circuit {:?}", self);
+                self.txn_proof_monolithic(input)
+            }
+            CircuitPersistence::Disk(TableLoadStrategy::OnDemand) => {
+                info!("using on demand circuit {:?}", self);
+                self.txn_proof_on_demand(input)
             }
         }
-        CircuitPersistence::Disk => {
-            info!("attempting to load preprocessed circuits from disk...");
-            let disk_state = persistence::prover_from_disk(&circuit_config);
-            match disk_state {
-                Some(circuits) => {
-                    info!("successfully loaded preprocessed circuits from disk");
-                    ProverState { state: circuits }
+    }
+
+    /// Initialize global prover state from the configuration.
+    pub fn initialize(&self) -> anyhow::Result<()> {
+        info!("initializing prover state...");
+
+        let state = match self.persistence {
+            CircuitPersistence::None => {
+                info!("generating circuits...");
+                ProverState {
+                    state: self.circuit_config.as_all_recursive_circuits(),
                 }
-                None => {
-                    info!("failed to load preprocessed circuits from disk. generating circuits...");
-                    let all_recursive_circuits = circuit_config.as_all_recursive_circuits();
-                    info!("saving preprocessed circuits to disk");
-                    persistence::to_disk(&all_recursive_circuits, &circuit_config);
-                    ProverState {
-                        state: all_recursive_circuits,
+            }
+            CircuitPersistence::Disk(strategy) => {
+                info!("attempting to load preprocessed circuits from disk...");
+
+                let disk_state = match strategy {
+                    TableLoadStrategy::OnDemand => BaseProverResource::get(&self.circuit_config),
+                    TableLoadStrategy::Monolithic => {
+                        MonolithicProverResource::get(&self.circuit_config)
+                    }
+                };
+
+                match disk_state {
+                    Ok(circuits) => {
+                        info!("successfully loaded preprocessed circuits from disk");
+                        ProverState { state: circuits }
+                    }
+                    Err(_) => {
+                        info!("failed to load preprocessed circuits from disk. generating circuits...");
+                        let all_recursive_circuits =
+                            self.circuit_config.as_all_recursive_circuits();
+                        info!("saving preprocessed circuits to disk");
+                        persistence::persist_all_to_disk(
+                            &all_recursive_circuits,
+                            &self.circuit_config,
+                        )?;
+                        ProverState {
+                            state: all_recursive_circuits,
+                        }
                     }
                 }
             }
-        }
-    };
+        };
 
-    P_STATE.set(state)
-}
+        P_STATE.set(state).map_err(|_| {
+            anyhow::Error::msg(
+                "prover state already set. check the program logic to ensure it is only set once",
+            )
+            .context("setting prover state")
+        })?;
 
-/// Loads a verifier state from disk or generate it.
-pub fn get_verifier_state_from_config(
-    ProverStateConfig {
-        circuit_config,
-        persistence,
-    }: ProverStateConfig,
-) -> VerifierState {
-    info!("initializing verifier state...");
-    match persistence {
-        CircuitPersistence::None => {
-            info!("generating circuit...");
-            let prover_state = circuit_config.as_all_recursive_circuits();
-            VerifierState {
-                state: prover_state.final_verifier_data(),
+        MANAGER.set(self.clone()).map_err(|_| {
+            anyhow::Error::msg(
+                "prover state manager already set. check the program logic to ensure it is only set once",
+            )
+            .context("setting prover state manager")
+        })?;
+
+        Ok(())
+    }
+
+    /// Loads a verifier state from disk or generate it.
+    pub fn verifier(&self) -> anyhow::Result<VerifierState> {
+        info!("initializing verifier state...");
+        match self.persistence {
+            CircuitPersistence::None => {
+                info!("generating circuit...");
+                let prover_state = self.circuit_config.as_all_recursive_circuits();
+                Ok(VerifierState {
+                    state: prover_state.final_verifier_data(),
+                })
             }
-        }
-        CircuitPersistence::Disk => {
-            info!("attempting to load preprocessed verifier circuit from disk...");
-            let disk_state = persistence::verifier_from_disk(&circuit_config);
-            match disk_state {
-                Some(state) => {
-                    info!("successfully loaded preprocessed verifier circuit from disk");
-                    VerifierState { state }
-                }
-                None => {
-                    info!(
-                        "failed to load preprocessed verifier circuit from disk. generating it..."
-                    );
-                    let prover_state = circuit_config.as_all_recursive_circuits();
+            CircuitPersistence::Disk(_) => {
+                info!("attempting to load preprocessed verifier circuit from disk...");
+                let disk_state = VerifierResource::get(&self.circuit_config);
 
-                    info!("saving preprocessed verifier circuit to disk");
-                    let state = prover_state.final_verifier_data();
-                    persistence::verifier_to_disk(&state, &circuit_config);
+                match disk_state {
+                    Ok(state) => {
+                        info!("successfully loaded preprocessed verifier circuit from disk");
+                        Ok(VerifierState { state })
+                    }
+                    Err(_) => {
+                        info!("failed to load preprocessed verifier circuit from disk. generating it...");
+                        let prover_state = self.circuit_config.as_all_recursive_circuits();
 
-                    VerifierState { state }
+                        info!("saving preprocessed verifier circuit to disk");
+                        let state = prover_state.final_verifier_data();
+                        VerifierResource::put(&self.circuit_config, &state)?;
+
+                        Ok(VerifierState { state })
+                    }
                 }
             }
         }

--- a/common/src/prover_state/mod.rs
+++ b/common/src/prover_state/mod.rs
@@ -163,7 +163,8 @@ impl ProverStateManager {
     }
 
     /// Generate a transaction proof using the specified input, loading the
-    /// circuit tables as needed to shrink the STARK proof.
+    /// circuit tables as needed to shrink the individual STARK proofs, and
+    /// finally aggregating them to a final transaction proof.
     fn txn_proof_on_demand(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
         let config = StarkConfig::standard_fast_config();
         let all_stark = AllStark::default();

--- a/common/src/prover_state/persistence.rs
+++ b/common/src/prover_state/persistence.rs
@@ -5,7 +5,6 @@ use std::{
     path::Path,
 };
 
-use evm_arithmetization::fixed_recursive_verifier::RecursiveCircuitsForTableSize;
 use plonky2::util::serialization::{
     Buffer, DefaultGateSerializer, DefaultGeneratorSerializer, IoError,
 };
@@ -14,7 +13,7 @@ use thiserror::Error;
 
 use super::{
     circuit::{Circuit, CircuitConfig},
-    Config, Field, SIZE,
+    Config, RecursiveCircuitsForTableSize, SIZE,
 };
 
 const PROVER_STATE_FILE_PREFIX: &str = "./prover_state";
@@ -154,7 +153,7 @@ impl DiskResource for MonolithicProverResource {
 pub(crate) struct RecursiveCircuitResource;
 
 impl DiskResource for RecursiveCircuitResource {
-    type Resource = RecursiveCircuitsForTableSize<Field, Config, SIZE>;
+    type Resource = RecursiveCircuitsForTableSize;
     type Error = IoError;
     type PathConstrutor = (Circuit, usize);
 
@@ -179,8 +178,7 @@ impl DiskResource for RecursiveCircuitResource {
 
     fn deserialize(
         bytes: &[u8],
-    ) -> Result<RecursiveCircuitsForTableSize<Field, Config, SIZE>, DiskResourceError<Self::Error>>
-    {
+    ) -> Result<RecursiveCircuitsForTableSize, DiskResourceError<Self::Error>> {
         let (gate_serializer, witness_serializer) = get_serializers();
         let mut buffer = Buffer::new(bytes);
         RecursiveCircuitsForTableSize::from_buffer(

--- a/common/src/prover_state/persistence.rs
+++ b/common/src/prover_state/persistence.rs
@@ -80,7 +80,9 @@ pub(crate) trait DiskResource {
     }
 }
 
-/// Pre-generated circuits containing just the three base circuits.
+/// Pre-generated circuits containing just the three higher-level circuits.
+/// These are sufficient for generating aggregation proofs and block
+/// proofs, but not for transaction proofs.
 #[derive(Debug, Default)]
 pub(crate) struct BaseProverResource;
 

--- a/common/src/prover_state/persistence.rs
+++ b/common/src/prover_state/persistence.rs
@@ -1,126 +1,256 @@
 use std::{
+    fmt::{Debug, Display},
     fs::{self, OpenOptions},
     io::Write,
+    path::Path,
 };
 
-use plonky2::{
-    plonk::config::PoseidonGoldilocksConfig,
-    util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
+use evm_arithmetization::fixed_recursive_verifier::RecursiveCircuitsForTableSize;
+use plonky2::util::serialization::{
+    Buffer, DefaultGateSerializer, DefaultGeneratorSerializer, IoError,
 };
 use proof_gen::types::{AllRecursiveCircuits, VerifierData};
-use tracing::{info, warn};
+use thiserror::Error;
 
-use super::circuit::CircuitConfig;
+use super::{
+    circuit::{Circuit, CircuitConfig},
+    Config, Field, SIZE,
+};
 
-type Config = PoseidonGoldilocksConfig;
-const SIZE: usize = 2;
 const PROVER_STATE_FILE_PREFIX: &str = "./prover_state";
 const VERIFIER_STATE_FILE_PREFIX: &str = "./verifier_state";
 
-fn get_serializers() -> (DefaultGateSerializer, DefaultGeneratorSerializer<Config, 2>) {
+fn get_serializers() -> (
+    DefaultGateSerializer,
+    DefaultGeneratorSerializer<Config, SIZE>,
+) {
     let gate_serializer = DefaultGateSerializer;
-    let witness_serializer: DefaultGeneratorSerializer<Config, SIZE> = DefaultGeneratorSerializer {
-        _phantom: Default::default(),
-    };
+    let witness_serializer: DefaultGeneratorSerializer<Config, SIZE> =
+        DefaultGeneratorSerializer::default();
 
     (gate_serializer, witness_serializer)
 }
 
-#[inline]
-fn disk_path(circuit_config: &CircuitConfig, prefix: &str) -> String {
-    format!("{}_{}", prefix, circuit_config.get_configuration_digest())
+#[derive(Error, Debug)]
+pub(crate) enum DiskResourceError<E> {
+    #[error("Serialization error: {0}")]
+    Serialization(E),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
-/// Loads [`AllRecursiveCircuits`] from disk.
-pub fn prover_from_disk(circuit_config: &CircuitConfig) -> Option<AllRecursiveCircuits> {
-    let path = disk_path(circuit_config, PROVER_STATE_FILE_PREFIX);
-    let bytes = fs::read(&path).ok()?;
-    info!("found prover state at {path}");
-    let (gate_serializer, witness_serializer) = get_serializers();
-    info!("deserializing prover state...");
-    let state =
-        AllRecursiveCircuits::from_bytes(&bytes, false, &gate_serializer, &witness_serializer);
+/// A trait for generic resources that may be written to and read from disk,
+/// each with their own serialization and deserialization logic.
+pub(crate) trait DiskResource {
+    /// The type of error that may arise while serializing or deserializing the
+    /// resource.
+    type Error: Debug + Display;
+    /// The type of resource being serialized, deserialized, and written to
+    /// disk.
+    type Resource;
+    /// The input type / configuration used to generate a unique path to the
+    /// resource on disk.
+    type PathConstrutor;
 
-    match state {
-        Ok(state) => Some(state),
-        Err(e) => {
-            warn!("failed to deserialize prover state, {e:?}");
-            None
-        }
+    /// Returns the path to the resource on disk.
+    fn path(p: &Self::PathConstrutor) -> impl AsRef<Path>;
+
+    /// Serializes the resource to bytes.
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>>;
+
+    /// Deserializes the resource from bytes.
+    fn deserialize(bytes: &[u8]) -> Result<Self::Resource, DiskResourceError<Self::Error>>;
+
+    /// Reads the resource from disk and deserializes it.
+    fn get(p: &Self::PathConstrutor) -> Result<Self::Resource, DiskResourceError<Self::Error>> {
+        Self::deserialize(&fs::read(Self::path(p))?)
+    }
+
+    /// Writes the resource to disk after serializing it.
+    fn put(
+        p: &Self::PathConstrutor,
+        r: &Self::Resource,
+    ) -> Result<(), DiskResourceError<Self::Error>> {
+        Ok(OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(Self::path(p))?
+            .write_all(&Self::serialize(r)?)?)
     }
 }
 
-/// Loads [`VerifierData`] from disk.
-pub fn verifier_from_disk(circuit_config: &CircuitConfig) -> Option<VerifierData> {
-    let path = disk_path(circuit_config, VERIFIER_STATE_FILE_PREFIX);
-    let bytes = fs::read(&path).ok()?;
-    info!("found verifier state at {path}");
-    let (gate_serializer, _witness_serializer) = get_serializers();
-    info!("deserializing verifier state...");
-    let state = VerifierData::from_bytes(bytes, &gate_serializer);
+/// Pre-generated circuits containing just the three base circuits.
+#[derive(Debug, Default)]
+pub(crate) struct BaseProverResource;
 
-    match state {
-        Ok(state) => Some(state),
-        Err(e) => {
-            warn!("failed to deserialize verifier state, {e:?}");
-            None
-        }
+impl DiskResource for BaseProverResource {
+    type Resource = AllRecursiveCircuits;
+    type Error = IoError;
+    type PathConstrutor = CircuitConfig;
+
+    fn path(p: &Self::PathConstrutor) -> String {
+        format!(
+            "{}_base_{}",
+            PROVER_STATE_FILE_PREFIX,
+            p.get_configuration_digest()
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+
+        r
+            // Note we are using the `true` flag to write only the upper circuits.
+            // The individual circuit tables are written separately below.
+            .to_bytes(true, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<AllRecursiveCircuits, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        AllRecursiveCircuits::from_bytes(bytes, true, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
     }
 }
 
-/// Writes the provided [`AllRecursiveCircuits`] to disk, along with the
-/// associated [`VerifierData`], in two distinct files.
-pub fn to_disk(circuits: &AllRecursiveCircuits, circuit_config: &CircuitConfig) {
-    prover_to_disk(circuits, circuit_config);
-    verifier_to_disk(&circuits.final_verifier_data(), circuit_config);
+/// Pre-generated circuits containing all circuits.
+#[derive(Debug, Default)]
+pub(crate) struct MonolithicProverResource;
+
+impl DiskResource for MonolithicProverResource {
+    type Resource = AllRecursiveCircuits;
+    type Error = IoError;
+    type PathConstrutor = CircuitConfig;
+
+    fn path(p: &Self::PathConstrutor) -> String {
+        format!(
+            "{}_monolithic_{}",
+            PROVER_STATE_FILE_PREFIX,
+            p.get_configuration_digest()
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+
+        r
+            // Note we are using the `false` flag to write all circuits.
+            .to_bytes(false, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<AllRecursiveCircuits, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        AllRecursiveCircuits::from_bytes(bytes, false, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+}
+
+/// An individual circuit table with a specific size.
+#[derive(Debug, Default)]
+pub(crate) struct RecursiveCircuitResource;
+
+impl DiskResource for RecursiveCircuitResource {
+    type Resource = RecursiveCircuitsForTableSize<Field, Config, SIZE>;
+    type Error = IoError;
+    type PathConstrutor = (Circuit, usize);
+
+    fn path((circuit_type, size): &Self::PathConstrutor) -> String {
+        format!(
+            "{}_{}_{}",
+            PROVER_STATE_FILE_PREFIX,
+            circuit_type.as_short_str(),
+            size
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        let mut buf = Vec::new();
+
+        r.to_buffer(&mut buf, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)?;
+
+        Ok(buf)
+    }
+
+    fn deserialize(
+        bytes: &[u8],
+    ) -> Result<RecursiveCircuitsForTableSize<Field, Config, SIZE>, DiskResourceError<Self::Error>>
+    {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        let mut buffer = Buffer::new(bytes);
+        RecursiveCircuitsForTableSize::from_buffer(
+            &mut buffer,
+            &gate_serializer,
+            &witness_serializer,
+        )
+        .map_err(DiskResourceError::Serialization)
+    }
+}
+
+/// An individual circuit table with a specific size.
+#[derive(Debug, Default)]
+pub(crate) struct VerifierResource;
+
+impl DiskResource for VerifierResource {
+    type Resource = VerifierData;
+    type Error = IoError;
+    type PathConstrutor = CircuitConfig;
+
+    fn path(p: &Self::PathConstrutor) -> String {
+        format!(
+            "{}_{}",
+            VERIFIER_STATE_FILE_PREFIX,
+            p.get_configuration_digest()
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, _witness_serializer) = get_serializers();
+        r.to_bytes(&gate_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<Self::Resource, DiskResourceError<Self::Error>> {
+        let (gate_serializer, _) = get_serializers();
+        VerifierData::from_bytes(bytes.to_vec(), &gate_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+}
+
+/// Writes the provided [`AllRecursiveCircuits`] to disk with all
+/// configurations, along with the associated [`VerifierData`].
+pub fn persist_all_to_disk(
+    circuits: &AllRecursiveCircuits,
+    circuit_config: &CircuitConfig,
+) -> anyhow::Result<()> {
+    prover_to_disk(circuit_config, circuits)?;
+    VerifierResource::put(circuit_config, &circuits.final_verifier_data())?;
+
+    Ok(())
 }
 
 /// Writes the provided [`AllRecursiveCircuits`] to disk.
-fn prover_to_disk(circuits: &AllRecursiveCircuits, circuit_config: &CircuitConfig) {
-    let (gate_serializer, witness_serializer) = get_serializers();
+///
+/// In particular, we cover both the monolothic and base prover states, as well
+/// as the individual circuit tables.
+fn prover_to_disk(
+    circuit_config: &CircuitConfig,
+    circuits: &AllRecursiveCircuits,
+) -> Result<(), DiskResourceError<IoError>> {
+    BaseProverResource::put(circuit_config, circuits)?;
+    MonolithicProverResource::put(circuit_config, circuits)?;
 
-    // Write prover state to disk
-    if let Err(e) = circuits
-        .to_bytes(false, &gate_serializer, &witness_serializer)
-        .map(|bytes| {
-            write_bytes_to_file(&bytes, disk_path(circuit_config, PROVER_STATE_FILE_PREFIX))
-        })
-    {
-        warn!("failed to create prover state file, {e:?}");
-    };
-}
-
-/// Writes the provided [`VerifierData`] to disk.
-pub fn verifier_to_disk(circuit: &VerifierData, circuit_config: &CircuitConfig) {
-    let (gate_serializer, _witness_serializer) = get_serializers();
-
-    // Write verifier state to disk
-    if let Err(e) = circuit.to_bytes(&gate_serializer).map(|bytes| {
-        write_bytes_to_file(
-            &bytes,
-            disk_path(circuit_config, VERIFIER_STATE_FILE_PREFIX),
-        )
-    }) {
-        warn!("failed to create verifier state file, {e:?}");
-    };
-}
-
-fn write_bytes_to_file(bytes: &[u8], path: String) {
-    let file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path);
-
-    let mut file = match file {
-        Ok(file) => file,
-        Err(e) => {
-            warn!("failed to create circuits file, {e:?}");
-            return;
+    // Write individual circuit tables to disk, by circuit type and size. This
+    // allows us to load only the necessary tables when needed.
+    for (circuit_type, tables) in circuits.by_table.iter().enumerate() {
+        let circuit_type: Circuit = circuit_type.into();
+        for (size, table) in tables.by_stark_size.iter() {
+            RecursiveCircuitResource::put(&(circuit_type, *size), table)?;
         }
-    };
-
-    if let Err(e) = file.write_all(bytes) {
-        warn!("failed to write circuits file, {e:?}");
     }
+
+    Ok(())
 }

--- a/leader/src/main.rs
+++ b/leader/src/main.rs
@@ -3,12 +3,11 @@ use std::{fs::File, path::PathBuf};
 use anyhow::Result;
 use clap::Parser;
 use cli::Command;
-use common::prover_state::set_prover_state_from_config;
+use common::prover_state::TableLoadStrategy;
 use dotenvy::dotenv;
 use ops::register;
 use paladin::runtime::Runtime;
 use proof_gen::types::PlonkyProofIntern;
-use tracing::warn;
 
 mod cli;
 mod http;
@@ -37,11 +36,14 @@ async fn main() -> Result<()> {
     if let paladin::config::Runtime::InMemory = args.paladin.runtime {
         // If running in emulation mode, we'll need to initialize the prover
         // state here.
-        if set_prover_state_from_config(args.prover_state_config.into()).is_err() {
-            warn!(
-                "prover state already set. check the program logic to ensure it is only set once"
-            );
-        }
+        let persistence = args.prover_state_config.persistence;
+        args.prover_state_config
+            .into_prover_state_manager(
+                // Use the monolithic load strategy for the prover state when running in
+                // emulation mode.
+                persistence.with_load_strategy(TableLoadStrategy::Monolithic),
+            )
+            .initialize()?;
     }
 
     let runtime = Runtime::from_config(&args.paladin, register()).await?;

--- a/leader/src/main.rs
+++ b/leader/src/main.rs
@@ -36,13 +36,11 @@ async fn main() -> Result<()> {
     if let paladin::config::Runtime::InMemory = args.paladin.runtime {
         // If running in emulation mode, we'll need to initialize the prover
         // state here.
-        let persistence = args.prover_state_config.persistence;
         args.prover_state_config
-            .into_prover_state_manager(
-                // Use the monolithic load strategy for the prover state when running in
-                // emulation mode.
-                persistence.with_load_strategy(TableLoadStrategy::Monolithic),
-            )
+            .into_prover_state_manager()
+            // Use the monolithic load strategy for the prover state when running in
+            // emulation mode.
+            .with_load_strategy(TableLoadStrategy::Monolithic)
             .initialize()?;
     }
 

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
 
     let verifer = args
         .prover_state_config
-        .into_prover_state_manager(Default::default())
+        .into_prover_state_manager()
         .verifier()?;
 
     verifer.verify(&input)?;

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 
 use anyhow::Result;
 use clap::Parser;
-use common::prover_state::get_verifier_state_from_config;
 use proof_gen::types::PlonkyProofIntern;
 use serde_json::Deserializer;
 
@@ -17,9 +16,12 @@ fn main() -> Result<()> {
     let des = &mut Deserializer::from_reader(&file);
     let input: PlonkyProofIntern = serde_path_to_error::deserialize(des)?;
 
-    let verifier_state = get_verifier_state_from_config(args.prover_state_config.into());
+    let verifer = args
+        .prover_state_config
+        .into_prover_state_manager(Default::default())
+        .verifier()?;
 
-    verifier_state.verify(&input)?;
+    verifer.verify(&input)?;
 
     Ok(())
 }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
-use common::prover_state::{cli::CliProverStateConfig, set_prover_state_from_config};
+use common::prover_state::{cli::CliProverStateConfig, TableLoadStrategy};
 use dotenvy::dotenv;
 use ops::register;
 use paladin::runtime::WorkerRuntime;
-use tracing::warn;
 
 mod init;
 
@@ -22,9 +21,10 @@ async fn main() -> Result<()> {
     init::tracing();
     let args = Cli::parse();
 
-    if set_prover_state_from_config(args.prover_state_config.into()).is_err() {
-        warn!("prover state already set. check the program logic to ensure it is only set once");
-    }
+    let persistence = args.prover_state_config.persistence;
+    args.prover_state_config
+        .into_prover_state_manager(persistence.with_load_strategy(TableLoadStrategy::OnDemand))
+        .initialize()?;
 
     let runtime = WorkerRuntime::from_config(&args.paladin, register()).await?;
     runtime.main_loop().await?;

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use common::prover_state::{cli::CliProverStateConfig, TableLoadStrategy};
+use common::prover_state::cli::CliProverStateConfig;
 use dotenvy::dotenv;
 use ops::register;
 use paladin::runtime::WorkerRuntime;
@@ -21,9 +21,8 @@ async fn main() -> Result<()> {
     init::tracing();
     let args = Cli::parse();
 
-    let persistence = args.prover_state_config.persistence;
     args.prover_state_config
-        .into_prover_state_manager(persistence.with_load_strategy(TableLoadStrategy::OnDemand))
+        .into_prover_state_manager()
         .initialize()?;
 
     let runtime = WorkerRuntime::from_config(&args.paladin, register()).await?;


### PR DESCRIPTION
This PR introduces on-demand recursive circuit loading as a means to reduce worker memory consumption.

The key change here is the combination piecemeal persistence of individual recursive circuits (e.g., Arithmetic 16) and on-demand loading of those individual recursive circuits based on the necessary degree bits given by the initial `AllProof` generated before shrinking when generating a transaction proof.

The persistence mechanism was also overhauled to provide a more unified interface for dealing with persisted resources. Users need not reason about generating unique paths, writing, reading, or serialization/deserialization of resources, as those are handled via an abstraction over the particular resource. 