### PR TITLE
Add test tooling for easier block / txn debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ name = "ops"
 version = "0.1.0"
 dependencies = [
  "common",
+ "evm_arithmetization",
  "paladin-core",
  "proof_gen",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,9 +969,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "evm_arithmetization"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d80801ec98b39dde6182d34f76f11abe050302f36d8847bfcd4456ecd990c9b"
+checksum = "ef2af65f5b147f04c94df5df5e21ff9d1632fd357511e183d5e04de059d6fa93"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1771,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "mpt_trie"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc408af26fe8f58787fb1be1a3bbfdd041bc36a15d4075fdadde07028469381"
+checksum = "bbf6d77f630021e46e127abfa047aebfba78bf207ed3dfd1c4f9e2370f9b60cd"
 dependencies = [
  "bytes",
  "enum-as-inner",
@@ -2303,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "proof_gen"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a304cfc3e741ebb7bc40258d0da52c0f2924b6817372d15f051e02673af3aa"
+checksum = "657003bc7dcee8b7c487807b8c9e6bf8aef8413f80501948a948b40c885ab7e7"
 dependencies = [
  "ethereum-types",
  "evm_arithmetization",
@@ -2910,9 +2910,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starky"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edb3b04ef3bb95f31805b9c88a9de39767089adadc1966ddc3c43348a11464a"
+checksum = "24e0a1eec739c7a67cb1c6f916c0b7bf2d281cf2edb35d3db5caa6989090133e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3239,9 +3239,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "trace_decoder"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5719c4c8f671ee782b78df96e7832207a2486a4fa137b20a3885beaf3a4ad724"
+checksum = "f08487265f29176ad03c894b1c1cf8da5adf9d82fc151b3191eb7f55350b5c58"
 dependencies = [
  "bytes",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethereum-types",
+ "futures",
  "ops",
  "paladin-core",
  "proof_gen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,16 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4.4.6", features = ["derive", "env"] }
 tokio = { version = "1.33.0", features = ["full"] }
 serde = "1.0.183"
-proof_gen = "0.1.0"
-trace_decoder = "0.1.0"
-evm_arithmetization = "0.1.0"
-plonky2 = "0.2.0"
 serde_path_to_error = "0.1.14"
 serde_json = "1.0.107"
 ethereum-types = "0.14.1"
 thiserror = "1.0.50"
+
+# zk-evm dependencies
+plonky2 = "0.2.0"
+evm_arithmetization = "0.1.1"
+trace_decoder = "0.1.1"
+proof_gen = "0.1.1"
 
 [workspace.package]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_path_to_error = "0.1.14"
 serde_json = "1.0.107"
 ethereum-types = "0.14.1"
 thiserror = "1.0.50"
+futures = "0.3.29"
 
 # zk-evm dependencies
 plonky2 = "0.2.0"

--- a/leader/Cargo.toml
+++ b/leader/Cargo.toml
@@ -28,3 +28,7 @@ ops = { path = "../ops" }
 prover = { path = "../prover" }
 rpc = { path = "../rpc" }
 common = { path = "../common" }
+
+[features]
+default = []
+test_only = ["ops/test_only", "prover/test_only"]

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -11,7 +11,12 @@ categories.workspace = true
 [dependencies]
 paladin-core = { workspace = true }
 serde = { workspace = true }
+evm_arithmetization = { workspace = true, optional = true}
 proof_gen = { workspace = true }
 trace_decoder = { workspace = true }
 
 common = { path = "../common" }
+
+[features]
+default = []
+test_only = ["evm_arithmetization"]

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -37,10 +37,8 @@ impl Operation for TxProof {
     type Output = ();
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        let _run = evm_arithmetization::prover::testing::simulate_execution::<
-            proof_gen::types::Field,
-        >(input)
-        .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
+        evm_arithmetization::prover::testing::simulate_execution::<proof_gen::types::Field>(input)
+            .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
 
         Ok(())
     }
@@ -73,7 +71,7 @@ impl Monoid for AggProof {
         Ok(())
     }
 
-    fn empty(&self) -> () {}
+    fn empty(&self) {}
 }
 
 #[derive(Deserialize, Serialize, RemoteExecute)]

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -3,11 +3,9 @@ use paladin::{
     operation::{FatalError, FatalStrategy, Monoid, Operation, Result},
     registry, RemoteExecute,
 };
-#[cfg(not(feature = "test_only"))]
-use proof_gen::{proof_gen::generate_agg_proof, proof_types::AggregatableProof};
 use proof_gen::{
-    proof_gen::generate_block_proof,
-    proof_types::{GeneratedAggProof, GeneratedBlockProof},
+    proof_gen::{generate_agg_proof, generate_block_proof},
+    proof_types::{AggregatableProof, GeneratedAggProof, GeneratedBlockProof},
 };
 use serde::{Deserialize, Serialize};
 use trace_decoder::types::TxnProofGenIR;
@@ -47,7 +45,6 @@ impl Operation for TxProof {
 #[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct AggProof;
 
-#[cfg(not(feature = "test_only"))]
 impl Monoid for AggProof {
     type Elem = AggregatableProof;
 
@@ -61,17 +58,6 @@ impl Monoid for AggProof {
         // Expect that empty blocks are padded.
         unimplemented!("empty agg proof")
     }
-}
-
-#[cfg(feature = "test_only")]
-impl Monoid for AggProof {
-    type Elem = ();
-
-    fn combine(&self, _a: Self::Elem, _b: Self::Elem) -> Result<Self::Elem> {
-        Ok(())
-    }
-
-    fn empty(&self) {}
 }
 
 #[derive(Deserialize, Serialize, RemoteExecute)]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 paladin-core = { workspace = true }
 ethereum-types = { workspace = true }
 anyhow = { workspace = true }
+futures = { workspace = true }
 
 # Local dependencies
 ops = { path = "../ops" }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -19,3 +19,7 @@ anyhow = { workspace = true }
 
 # Local dependencies
 ops = { path = "../ops" }
+
+[features]
+default = ["test_only"]
+test_only = ["ops/test_only"]

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -82,7 +82,7 @@ impl ProverInput {
             other_data.clone(),
         )?;
 
-        let _res = IndexedStream::from(txs)
+        IndexedStream::from(txs)
             .map(&TxProof)
             .fold(&AggProof)
             .run(runtime)
@@ -91,9 +91,9 @@ impl ProverInput {
         info!("Successfully generated witness for block {block_number}");
 
         // Dummy proof to match expected output type
-        return Ok(GeneratedBlockProof {
+        Ok(GeneratedBlockProof {
             b_height: block_number.as_u64(),
             intern: proof_gen::proof_gen::dummy_proof()?,
-        });
+        })
     }
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -74,7 +74,7 @@ impl ProverInput {
         _previous: Option<PlonkyProofIntern>,
     ) -> Result<GeneratedBlockProof> {
         let block_number = self.get_block_number();
-        info!("Testing witness generation for block {block_number}");
+        info!("Testing witness generation for block {block_number}.");
 
         let other_data = self.other_data;
         let txs = self.block_trace.into_txn_proof_gen_ir(
@@ -88,9 +88,9 @@ impl ProverInput {
             .run(runtime)
             .await?;
 
-        info!("Successfully generated witness for block {block_number}");
+        info!("Successfully generated witness for block {block_number}.");
 
-        // Dummy proof to match expected output type
+        // Dummy proof to match expected output type.
         Ok(GeneratedBlockProof {
             b_height: block_number.as_u64(),
             intern: proof_gen::proof_gen::dummy_proof()?,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -21,7 +21,10 @@ clap = { workspace = true }
 ethereum-types = { workspace = true }
 evm_arithmetization = { workspace = true }
 thiserror = { workspace = true }
+futures = { workspace = true }
 
+hex = "0.4.3"
+hex-literal = "0.4.1"
 reqwest = { version = "0.11.22", default-features = false, features = [
   "json",
   "rustls-tls",
@@ -30,7 +33,4 @@ reqwest = { version = "0.11.22", default-features = false, features = [
 
 # Local dependencies
 common = { path = "../common" }
-futures = "0.3.29"
-hex = "0.4.3"
-hex-literal = "0.4.1"
 prover = { path = "../prover" }

--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Args:
+# 1 --> Block idx
+# 2 --> Rpc endpoint:port (eg. http://35.246.1.96:8545)
+
+export RUST_BACKTRACE=1
+export RUST_LOG=plonky2=info,evm_arithmetization=trace
+
+# Speciying smallest ranges, as we won't need them anyway.
+export ARTITHMETIC_CIRCUIT_SIZE="16..17"
+export BYTE_PACKING_CIRCUIT_SIZE="9..10"
+export CPU_CIRCUIT_SIZE="12..13"
+export KECCAK_CIRCUIT_SIZE="14..15"
+export KECCAK_SPONGE_CIRCUIT_SIZE="9..10"
+export LOGIC_CIRCUIT_SIZE="12..13"
+export MEMORY_CIRCUIT_SIZE="17..18"
+
+OUTPUT_DIR="debug"
+OUT_DUMMY_PROOF_PATH="${OUTPUT_DIR}/b${1}.zkproof"
+OUT_LOG_PATH="${OUTPUT_DIR}/b${1}.log"
+
+echo "Testing block ${1}..."
+mkdir -p $OUTPUT_DIR
+
+cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$2" --block-number "$1" --proof-output-path $OUT_DUMMY_PROOF_PATH > $OUT_LOG_PATH 2>&1
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    # Some error occured.
+    echo "Witness generation for block ${1} errored. See ${OUT_LOG_PATH} for more details."
+else
+    echo "Witness generation for block ${1} succeeded."
+    # Remove the log / dummy proof on success.
+    rm $OUT_DUMMY_PROOF_PATH
+    rm $OUT_LOG_PATH
+fi
+

--- a/tools/prove_blocks.sh
+++ b/tools/prove_blocks.sh
@@ -7,18 +7,18 @@
 # 4 --> Ignore previous proofs (boolean)
 
 export RUST_BACKTRACE=1
-export RUST_LOG=plonky2=info,evm_arithmetization=info
+export RUST_LOG=plonky2=trace,evm_arithmetization=trace
 
-export ARTITHMETIC_CIRCUIT_SIZE="16..17"
-export BYTE_PACKING_CIRCUIT_SIZE="9..10"
-export CPU_CIRCUIT_SIZE="12..13"
-export KECCAK_CIRCUIT_SIZE="14..15"
-export KECCAK_SPONGE_CIRCUIT_SIZE="9..10"
-export LOGIC_CIRCUIT_SIZE="12..13"
-export MEMORY_CIRCUIT_SIZE="17..18"
+export ARTITHMETIC_CIRCUIT_SIZE="16..23"
+export BYTE_PACKING_CIRCUIT_SIZE="9..21"
+export CPU_CIRCUIT_SIZE="12..25"
+export KECCAK_CIRCUIT_SIZE="14..20"
+export KECCAK_SPONGE_CIRCUIT_SIZE="9..15"
+export LOGIC_CIRCUIT_SIZE="12..18"
+export MEMORY_CIRCUIT_SIZE="17..28"
 
 PROOF_OUTPUT_DIR="proofs"
-ALWAYS_WRITE_LOGS=1 # Change this to `1` if you always want logs to be written.
+ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.
 
 TOT_BLOCKS=$(($2-$1+1))
 IGNORE_PREVIOUS_PROOFS=$4
@@ -44,12 +44,13 @@ do
         fi
     fi
 
-    cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$3" --block-number $i --proof-output-path $OUT_PROOF_PATH $PREV_PROOF_EXTRA_ARG > $OUT_LOG_PATH 2>&1
+    cargo r --release --bin leader -- --runtime in-memory jerigon --rpc-url "$3" --block-number $i --proof-output-path $OUT_PROOF_PATH $PREV_PROOF_EXTRA_ARG > $OUT_LOG_PATH 2>&1
     
     retVal=$?
     if [ $retVal -ne 0 ]; then
         # Some error occured.
         echo "Block ${i} errored. See ${OUT_LOG_PATH} for more details."
+        exit $retVal
     else
         # Remove the log on success if we don't want to keep it.
         if [ $ALWAYS_WRITE_LOGS -ne 1 ]; then

--- a/tools/prove_blocks.sh
+++ b/tools/prove_blocks.sh
@@ -7,24 +7,24 @@
 # 4 --> Ignore previous proofs (boolean)
 
 export RUST_BACKTRACE=1
-export RUST_LOG=plonky2=trace,evm_arithmetization=trace
+export RUST_LOG=plonky2=info,evm_arithmetization=info
 
-export ARTITHMETIC_CIRCUIT_SIZE="16..23"
-export BYTE_PACKING_CIRCUIT_SIZE="9..21"
-export CPU_CIRCUIT_SIZE="12..25"
-export KECCAK_CIRCUIT_SIZE="14..20"
-export KECCAK_SPONGE_CIRCUIT_SIZE="9..15"
-export LOGIC_CIRCUIT_SIZE="12..18"
-export MEMORY_CIRCUIT_SIZE="17..28"
+export ARTITHMETIC_CIRCUIT_SIZE="16..17"
+export BYTE_PACKING_CIRCUIT_SIZE="9..10"
+export CPU_CIRCUIT_SIZE="12..13"
+export KECCAK_CIRCUIT_SIZE="14..15"
+export KECCAK_SPONGE_CIRCUIT_SIZE="9..10"
+export LOGIC_CIRCUIT_SIZE="12..13"
+export MEMORY_CIRCUIT_SIZE="17..18"
 
 PROOF_OUTPUT_DIR="proofs"
-ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.
+ALWAYS_WRITE_LOGS=1 # Change this to `1` if you always want logs to be written.
 
 TOT_BLOCKS=$(($2-$1+1))
 IGNORE_PREVIOUS_PROOFS=$4
 
 echo "Proving blocks ${1}..=${2}... (Total: ${TOT_BLOCKS})"
-mkdir -p proofs/
+mkdir -p $PROOF_OUTPUT_DIR
 
 for ((i=$1; i<=$2; i++))
 do
@@ -44,13 +44,12 @@ do
         fi
     fi
 
-    cargo r --release --bin leader -- --runtime in-memory jerigon --rpc-url "$3" --block-number $i --proof-output-path $OUT_PROOF_PATH $PREV_PROOF_EXTRA_ARG > $OUT_LOG_PATH 2>&1
+    cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$3" --block-number $i --proof-output-path $OUT_PROOF_PATH $PREV_PROOF_EXTRA_ARG > $OUT_LOG_PATH 2>&1
     
     retVal=$?
     if [ $retVal -ne 0 ]; then
         # Some error occured.
         echo "Block ${i} errored. See ${OUT_LOG_PATH} for more details."
-        exit $retVal
     else
         # Remove the log on success if we don't want to keep it.
         if [ $ALWAYS_WRITE_LOGS -ne 1 ]; then


### PR DESCRIPTION
This PR adds a testing logic that replaces actual proof generation / aggregation. It contains:

- bump of `zk_evm` crates to `v0.1.1`
- new feature flag `test_only` for the `leader` / `prover` / `ops` crates, that allows replacing the `Operation` trait implementation for `TxnProof` by simple witness generation without actual proving, and replacing `AggProof` trait implementation to be a no-op. Running with the feature flag activated will yield a dummy proof, corresponding to a meaningless dummy circuit, so as to not change the expected return types.
- a new debugging script, `debug_block.sh`, that takes a block index and an RPC endpoint, and will try generating all the proof witnesses for this block. It will maintain the log on disk upon failure, and flush it upon success. It uses minimal default ranges as to not waste disk space (as circuits aren't used for witness generation anyway).