### PR TITLE
Fix checkpoint block for debugging script

### DIFF
--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -8,7 +8,7 @@ export RUST_BACKTRACE=1
 export RUST_LOG=plonky2=info,evm_arithmetization=trace
 
 # Speciying smallest ranges, as we won't need them anyway.
-export ARTITHMETIC_CIRCUIT_SIZE="16..17"
+export ARITHMETIC_CIRCUIT_SIZE="16..17"
 export BYTE_PACKING_CIRCUIT_SIZE="9..10"
 export CPU_CIRCUIT_SIZE="12..13"
 export KECCAK_CIRCUIT_SIZE="14..15"

--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -23,7 +23,7 @@ OUT_LOG_PATH="${OUTPUT_DIR}/b${1}.log"
 echo "Testing block ${1}..."
 mkdir -p $OUTPUT_DIR
 
-cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$2" --block-number "$1" --proof-output-path $OUT_DUMMY_PROOF_PATH > $OUT_LOG_PATH 2>&1
+cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$2" --block-number "$1" --checkpoint-block-number "$(($1-1))" --proof-output-path $OUT_DUMMY_PROOF_PATH > $OUT_LOG_PATH 2>&1
 retVal=$?
 if [ $retVal -ne 0 ]; then
     # Some error occured.

--- a/tools/prove_blocks.sh
+++ b/tools/prove_blocks.sh
@@ -9,7 +9,7 @@
 export RUST_BACKTRACE=1
 export RUST_LOG=plonky2=trace,evm_arithmetization=trace
 
-export ARTITHMETIC_CIRCUIT_SIZE="16..23"
+export ARITHMETIC_CIRCUIT_SIZE="16..23"
 export BYTE_PACKING_CIRCUIT_SIZE="9..21"
 export CPU_CIRCUIT_SIZE="12..25"
 export KECCAK_CIRCUIT_SIZE="14..20"


### PR DESCRIPTION
As @BGluth noticed, the debugging script may fail on long chains as the `checkpoint-block-number` is not set, and then defaults to 0.
As it is not used anyway for debugging, we can just set it to the previous block, as it could be in practice, similarly to the proving script.

Also fix an environment variable name in both scripts, as it was containing a typo and hence ignored when running.