### PR TITLE
Update circuits location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 /target
-/prover_state
+
+# Default extension for generated block proofs
 *.zkproof
-prover_state_*
-verifier_state_*
+
+# Folder containing all the locally generated circuit data
+circuits/
+
+# Folders containing logs from the utility scripts in tools/
+debug/
+proofs/


### PR DESCRIPTION
Currently, all generated circuits data are stored at the root level, which view becomes quite clogged, especially since #21 which stores them all individually on disk.

This moves them to a dedicated `circuits` folder, and also updates `.gitignore` following latest changes with tooling scripts.

closes #26 