### PR TITLE
Fixed proof gen debug script not forcing `1` worker

### DIFF
--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -5,6 +5,7 @@
 # 2 --> Rpc endpoint:port (eg. http://35.246.1.96:8545)
 
 export RUST_BACKTRACE=1
+export RUST_MIN_STACK=8388608
 export RUST_LOG=mpt_trie=info,trace_decoder=info,plonky2=info,evm_arithmetization=trace
 
 # Speciying smallest ranges, as we won't need them anyway.

--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -5,7 +5,7 @@
 # 2 --> Rpc endpoint:port (eg. http://35.246.1.96:8545)
 
 export RUST_BACKTRACE=1
-export RUST_LOG=plonky2=info,evm_arithmetization=trace
+export RUST_LOG=mpt_trie=info,trace_decoder=info,plonky2=info,evm_arithmetization=trace
 
 # Speciying smallest ranges, as we won't need them anyway.
 export ARITHMETIC_CIRCUIT_SIZE="16..17"
@@ -23,7 +23,7 @@ OUT_LOG_PATH="${OUTPUT_DIR}/b${1}.log"
 echo "Testing block ${1}..."
 mkdir -p $OUTPUT_DIR
 
-cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$2" --block-number "$1" --checkpoint-block-number "$(($1-1))" --proof-output-path $OUT_DUMMY_PROOF_PATH > $OUT_LOG_PATH 2>&1
+cargo r --release --features test_only --bin leader -- -n 1 --runtime in-memory jerigon --rpc-url "$2" --block-number "$1" --checkpoint-block-number "$(($1-1))" --proof-output-path $OUT_DUMMY_PROOF_PATH > $OUT_LOG_PATH 2>&1
 retVal=$?
 if [ $retVal -ne 0 ]; then
     # Some error occured.


### PR DESCRIPTION
This was a fix made by @Nashtare on a testing branch, but it really should make it's way into `main`.