### PR TITLE
Now works on pre-eip-4895 blocks

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -104,6 +104,9 @@ struct EthGetBlockByNumberResult {
     parent_hash: H256,
     state_root: H256,
     timestamp: U256,
+
+    // Pre-eip-4895 blocks won't have this field, so if it's missing, using an empty vec is fine.
+    #[serde(default)]
     withdrawals: Vec<Withdrawal>,
 }
 


### PR DESCRIPTION
- This EIP added `withdrawals` which added the `withdrawal` field to the `zeroTracer` payload. The decoder always expected this field to be present, but now just uses an empty withdrawal vec in the case that this is missing.