### PR TITLE
Update prover default features

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -22,5 +22,5 @@ futures = { workspace = true }
 ops = { path = "../ops" }
 
 [features]
-default = ["test_only"]
+default = []
 test_only = ["ops/test_only"]

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ethereum_types::U256;
+#[cfg(feature = "test_only")]
 use futures::stream::TryStreamExt;
 use ops::TxProof;
 use paladin::{

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -56,7 +56,7 @@ impl ProverInput {
                 intern: p,
             });
 
-            let block_proof = paladin::Literal(proof)
+            let block_proof = paladin::directive::Literal(proof)
                 .map(&ops::BlockProof { prev })
                 .run(runtime)
                 .await?;


### PR DESCRIPTION
It seems the prover by default enables test-only feature, which is supposed to be used in debug only mode.