### PR TITLE
Reduce verbosity in logs

### DIFF
--- a/leader/src/init.rs
+++ b/leader/src/init.rs
@@ -1,10 +1,10 @@
-use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
 pub(crate) fn tracing() {
     tracing_subscriber::Registry::default()
         .with(
             tracing_subscriber::fmt::layer()
-                .pretty()
-                .with_span_events(FmtSpan::CLOSE)
+                .with_ansi(false)
+                .compact()
                 .with_filter(EnvFilter::from_default_env()),
         )
         .init();

--- a/rpc/src/init.rs
+++ b/rpc/src/init.rs
@@ -1,10 +1,10 @@
-use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
 pub(crate) fn tracing() {
     tracing_subscriber::Registry::default()
         .with(
             tracing_subscriber::fmt::layer()
-                .pretty()
-                .with_span_events(FmtSpan::CLOSE)
+                .with_ansi(false)
+                .compact()
                 .with_filter(EnvFilter::from_default_env()),
         )
         .init();

--- a/verifier/src/init.rs
+++ b/verifier/src/init.rs
@@ -1,10 +1,10 @@
-use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
 pub(crate) fn tracing() {
     tracing_subscriber::Registry::default()
         .with(
             tracing_subscriber::fmt::layer()
-                .pretty()
-                .with_span_events(FmtSpan::CLOSE)
+                .with_ansi(false)
+                .compact()
                 .with_filter(EnvFilter::from_default_env()),
         )
         .init();

--- a/worker/src/init.rs
+++ b/worker/src/init.rs
@@ -1,10 +1,10 @@
-use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
 pub(crate) fn tracing() {
     tracing_subscriber::Registry::default()
         .with(
             tracing_subscriber::fmt::layer()
-                .pretty()
-                .with_span_events(FmtSpan::CLOSE)
+                .with_ansi(false)
+                .compact()
                 .with_filter(EnvFilter::from_default_env()),
         )
         .init();


### PR DESCRIPTION
Initially suggested by @BGluth in the testing branch, but I'm getting so bothered by the increased verbosity in logs that I'm suggesting to include it inside `develop`. Below is an example of the difference it yields, between the same section (during initial RPC calls). It reduces by almost 30% the log size, which can be quite significant savings, and also makes them much more readable right away.

### Current
<img width="1217" alt="Screenshot 2024-04-08 at 9 29 41 AM" src="https://github.com/0xPolygonZero/zero-bin/assets/30937548/0742de42-a00d-4d89-b952-4f22b7d36d58">

### Suggested
<img width="1209" alt="Screenshot 2024-04-08 at 9 34 56 AM" src="https://github.com/0xPolygonZero/zero-bin/assets/30937548/eddd50d7-5cee-4aac-8995-bf272a61c9d6">
