### PR TITLE
Debug & proving scripts now use indentical logging

### DIFF
--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -6,7 +6,7 @@
 
 export RUST_BACKTRACE=1
 export RUST_MIN_STACK=8388608
-export RUST_LOG=mpt_trie=info,trace_decoder=info,plonky2=info,evm_arithmetization=trace
+export RUST_LOG=mpt_trie=info,trace_decoder=info,plonky2=info,evm_arithmetization=trace,leader=info
 
 # Speciying smallest ranges, as we won't need them anyway.
 export ARITHMETIC_CIRCUIT_SIZE="16..17"

--- a/tools/prove_blocks.sh
+++ b/tools/prove_blocks.sh
@@ -7,7 +7,7 @@
 # 4 --> Ignore previous proofs (boolean)
 
 export RUST_BACKTRACE=1
-export RUST_LOG=plonky2=trace,evm_arithmetization=trace
+export RUST_LOG=mpt_trie=info,trace_decoder=info,plonky2=info,evm_arithmetization=trace,leader=info
 
 export ARITHMETIC_CIRCUIT_SIZE="16..23"
 export BYTE_PACKING_CIRCUIT_SIZE="9..21"


### PR DESCRIPTION
I switched both testing scripts in `tools` to use identical logging configurations. However, I forced both of them to use `info` instead of `trace`, which I'm not sure if this is the best. `trace` is extremely verbose for `evm_arithmetization`, so I thought that maybe we should downgrade it to `info` as a default.

Also added some modules that were missing from `RUST_LOG`.