### PR TITLE
Load .env file in verifier binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,6 +3640,7 @@ dependencies = [
  "anyhow",
  "clap",
  "common",
+ "dotenvy",
  "proof_gen",
  "serde",
  "serde_json",

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+dotenvy = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 
 use anyhow::Result;
 use clap::Parser;
+use dotenvy::dotenv;
 use proof_gen::types::PlonkyProofIntern;
 use serde_json::Deserializer;
 
@@ -9,6 +10,7 @@ mod cli;
 mod init;
 
 fn main() -> Result<()> {
+    dotenv().ok();
     init::tracing();
 
     let args = cli::Cli::parse();

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use dotenvy::dotenv;
 use proof_gen::types::PlonkyProofIntern;
 use serde_json::Deserializer;
+use tracing::info;
 
 mod cli;
 mod init;
@@ -23,7 +24,10 @@ fn main() -> Result<()> {
         .into_prover_state_manager()
         .verifier()?;
 
-    verifer.verify(&input)?;
+    match verifer.verify(&input) {
+        Ok(_) => info!("Proof verified successfully!"),
+        Err(e) => info!("Proof verification failed with error: {:?}", e),
+    };
 
     Ok(())
 }


### PR DESCRIPTION
The verifier binary doesn't allow loading the `.env` file, possibly causing circuit discrepancies when verifying a proof, if the ranges are not specified as args.

Also adds verification result in logs.