### PR TITLE
Now logs time to generate proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,11 +2104,15 @@ name = "ops"
 version = "0.1.0"
 dependencies = [
  "common",
+ "ethereum-types",
  "evm_arithmetization",
+ "keccak-hash 0.10.0",
  "paladin-core",
  "proof_gen",
+ "rlp",
  "serde",
  "trace_decoder",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ serde_json = "1.0.107"
 ethereum-types = "0.14.1"
 thiserror = "1.0.50"
 futures = "0.3.29"
+rlp = "0.5.2"
+keccak-hash = "0.10.0"
 
 # zk-evm dependencies
 plonky2 = "0.2.0"

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -14,6 +14,10 @@ serde = { workspace = true }
 evm_arithmetization = { workspace = true, optional = true}
 proof_gen = { workspace = true }
 trace_decoder = { workspace = true }
+tracing = { workspace = true }
+rlp = { workspace = true }
+ethereum-types = "0.14.1"
+keccak-hash = { workspace = true }
 
 common = { path = "../common" }
 

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -16,7 +16,7 @@ proof_gen = { workspace = true }
 trace_decoder = { workspace = true }
 tracing = { workspace = true }
 rlp = { workspace = true }
-ethereum-types = "0.14.1"
+ethereum-types = { workspace = true }
 keccak-hash = { workspace = true }
 
 common = { path = "../common" }

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{ops::RangeInclusive, time::Instant};
+use std::time::Instant;
 
 use common::prover_state::p_state;
 use keccak_hash::keccak;
@@ -11,7 +11,7 @@ use proof_gen::{
     proof_types::{AggregatableProof, GeneratedAggProof, GeneratedBlockProof},
 };
 use serde::{Deserialize, Serialize};
-use trace_decoder::types::{BlockHeight, TxnProofGenIR};
+use trace_decoder::types::TxnProofGenIR;
 use tracing::{event, info_span, Level};
 
 registry!();
@@ -19,7 +19,7 @@ registry!();
 #[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct TxProof;
 
-fn run_and_wrap_closure_in_elapsed_span<F, O>(f: F, ident: String) -> Result<O>
+fn run_and_wrap_txn_proof_in_elapsed_span<F, O>(f: F, ident: String) -> Result<O>
 where
     F: Fn() -> Result<O>,
 {
@@ -28,7 +28,12 @@ where
 
     let proof = f()?;
 
-    event!(Level::INFO, "Proof {:.4} took {:?}", ident, start.elapsed());
+    event!(
+        Level::INFO,
+        "txn proof {:.4} took {:?}",
+        ident,
+        start.elapsed()
+    );
     Ok(proof)
 }
 
@@ -40,7 +45,7 @@ impl Operation for TxProof {
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
         let txn_ident = Self::txn_ident(&input);
 
-        let proof = run_and_wrap_closure_in_elapsed_span(
+        let proof = run_and_wrap_txn_proof_in_elapsed_span(
             || {
                 common::prover_state::p_manager()
                     .generate_txn_proof(input.clone())
@@ -61,7 +66,7 @@ impl Operation for TxProof {
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
         let txn_ident = Self::txn_ident(&input);
 
-        run_and_wrap_closure_in_elapsed_span(
+        run_and_wrap_txn_proof_in_elapsed_span(
             || {
                 evm_arithmetization::prover::testing::simulate_execution::<proof_gen::types::Field>(
                     input.clone(),
@@ -84,7 +89,7 @@ impl TxProof {
             .unwrap_or_else(|| "Dummy".to_string());
 
         format!(
-            "Txn b{} - {} ({})",
+            "b{} - {} ({})",
             ir.block_metadata.block_number, ir.txn_number_before, txn_hash_str
         )
     }
@@ -97,11 +102,7 @@ impl Monoid for AggProof {
     type Elem = AggregatableProof;
 
     fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
-        let ident = Self::agg_ident(&a, &b);
-        let result = run_and_wrap_closure_in_elapsed_span(
-            || generate_agg_proof(p_state(), &a, &b).map_err(|e| FatalError::from(e).into()),
-            ident,
-        )?;
+        let result = generate_agg_proof(p_state(), &a, &b).map_err(FatalError::from)?;
 
         Ok(result.into())
     }
@@ -109,21 +110,6 @@ impl Monoid for AggProof {
     fn empty(&self) -> Self::Elem {
         // Expect that empty blocks are padded.
         unimplemented!("empty agg proof")
-    }
-}
-
-impl AggProof {
-    fn agg_ident(a: &AggregatableProof, b: &AggregatableProof) -> String {
-        let b_height = b_height_from_aggregatable_proof(a);
-        let a_range = proof_range_from_aggregatable_proof(a);
-        let b_range = proof_range_from_aggregatable_proof(b);
-
-        format!(
-            "Agg b{} - {}..={}",
-            b_height,
-            *a_range.start(),
-            *b_range.end()
-        )
     }
 }
 
@@ -137,50 +123,9 @@ impl Operation for BlockProof {
     type Output = GeneratedBlockProof;
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        let ident = Self::block_ident(&input);
-
-        run_and_wrap_closure_in_elapsed_span(
-            || {
-                generate_block_proof(p_state(), self.prev.as_ref(), &input)
-                    .map_err(|e| FatalError::from(e).into())
-            },
-            ident,
+        Ok(
+            generate_block_proof(p_state(), self.prev.as_ref(), &input)
+                .map_err(FatalError::from)?,
         )
-    }
-}
-
-impl BlockProof {
-    fn block_ident(p: &GeneratedAggProof) -> String {
-        let b_height = p.p_vals.block_metadata.block_number;
-        let b_range = aggregated_proof_range(p);
-
-        format!(
-            "Block b{} ({}..={})",
-            b_height,
-            *b_range.start(),
-            *b_range.end()
-        )
-    }
-}
-
-fn proof_range_from_aggregatable_proof(p: &AggregatableProof) -> RangeInclusive<usize> {
-    match p {
-        AggregatableProof::Txn(info) => {
-            let txn_idx = info.p_vals.extra_block_data.txn_number_before.as_usize();
-            txn_idx..=txn_idx
-        }
-        AggregatableProof::Agg(info) => aggregated_proof_range(info),
-    }
-}
-
-fn aggregated_proof_range(p: &GeneratedAggProof) -> RangeInclusive<usize> {
-    p.p_vals.extra_block_data.txn_number_before.as_usize()
-        ..=p.p_vals.extra_block_data.txn_number_after.as_usize()
-}
-
-fn b_height_from_aggregatable_proof(p: &AggregatableProof) -> BlockHeight {
-    match p {
-        AggregatableProof::Txn(info) => info.p_vals.block_metadata.block_number.as_u64(),
-        AggregatableProof::Agg(info) => info.p_vals.block_metadata.block_number.as_u64(),
     }
 }

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -1,4 +1,7 @@
+use std::{ops::RangeInclusive, time::Instant};
+
 use common::prover_state::p_state;
+use keccak_hash::keccak;
 use paladin::{
     operation::{FatalError, FatalStrategy, Monoid, Operation, Result},
     registry, RemoteExecute,
@@ -8,12 +11,26 @@ use proof_gen::{
     proof_types::{AggregatableProof, GeneratedAggProof, GeneratedBlockProof},
 };
 use serde::{Deserialize, Serialize};
-use trace_decoder::types::TxnProofGenIR;
+use trace_decoder::types::{BlockHeight, TxnProofGenIR};
+use tracing::{event, info_span, Level};
 
 registry!();
 
 #[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct TxProof;
+
+fn run_and_wrap_closure_in_elapsed_span<F, O>(f: F, ident: String) -> Result<O>
+where
+    F: Fn() -> Result<O>,
+{
+    let _span = info_span!("proof generation", ident).entered();
+    let start = Instant::now();
+
+    let proof = f()?;
+
+    event!(Level::INFO, "Proof {:.4} took {:?}", ident, start.elapsed());
+    Ok(proof)
+}
 
 #[cfg(not(feature = "test_only"))]
 impl Operation for TxProof {
@@ -21,9 +38,16 @@ impl Operation for TxProof {
     type Output = proof_gen::proof_types::AggregatableProof;
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        let proof = common::prover_state::p_manager()
-            .generate_txn_proof(input)
-            .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
+        let txn_ident = Self::txn_ident(&input);
+
+        let proof = run_and_wrap_closure_in_elapsed_span(
+            || {
+                common::prover_state::p_manager()
+                    .generate_txn_proof(input.clone())
+                    .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate).into())
+            },
+            txn_ident,
+        )?;
 
         Ok(proof.into())
     }
@@ -35,10 +59,34 @@ impl Operation for TxProof {
     type Output = ();
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        evm_arithmetization::prover::testing::simulate_execution::<proof_gen::types::Field>(input)
-            .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
+        let txn_ident = Self::txn_ident(&input);
+
+        run_and_wrap_closure_in_elapsed_span(
+            || {
+                evm_arithmetization::prover::testing::simulate_execution::<proof_gen::types::Field>(
+                    input.clone(),
+                )
+                .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate).into())
+            },
+            txn_ident,
+        )?;
 
         Ok(())
+    }
+}
+
+impl TxProof {
+    fn txn_ident(ir: &TxnProofGenIR) -> String {
+        let txn_hash_str = ir
+            .signed_txn
+            .as_ref()
+            .map(|txn| format!("{:x}", keccak(txn)))
+            .unwrap_or_else(|| "Dummy".to_string());
+
+        format!(
+            "Txn b{} - {} ({})",
+            ir.block_metadata.block_number, ir.txn_number_before, txn_hash_str
+        )
     }
 }
 
@@ -49,7 +97,11 @@ impl Monoid for AggProof {
     type Elem = AggregatableProof;
 
     fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
-        let result = generate_agg_proof(p_state(), &a, &b).map_err(FatalError::from)?;
+        let ident = Self::agg_ident(&a, &b);
+        let result = run_and_wrap_closure_in_elapsed_span(
+            || generate_agg_proof(p_state(), &a, &b).map_err(|e| FatalError::from(e).into()),
+            ident,
+        )?;
 
         Ok(result.into())
     }
@@ -57,6 +109,21 @@ impl Monoid for AggProof {
     fn empty(&self) -> Self::Elem {
         // Expect that empty blocks are padded.
         unimplemented!("empty agg proof")
+    }
+}
+
+impl AggProof {
+    fn agg_ident(a: &AggregatableProof, b: &AggregatableProof) -> String {
+        let b_height = b_height_from_aggregatable_proof(a);
+        let a_range = proof_range_from_aggregatable_proof(a);
+        let b_range = proof_range_from_aggregatable_proof(b);
+
+        format!(
+            "Agg b{} - {}..={}",
+            b_height,
+            *a_range.start(),
+            *b_range.end()
+        )
     }
 }
 
@@ -70,9 +137,50 @@ impl Operation for BlockProof {
     type Output = GeneratedBlockProof;
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        Ok(
-            generate_block_proof(p_state(), self.prev.as_ref(), &input)
-                .map_err(FatalError::from)?,
+        let ident = Self::block_ident(&input);
+
+        run_and_wrap_closure_in_elapsed_span(
+            || {
+                generate_block_proof(p_state(), self.prev.as_ref(), &input)
+                    .map_err(|e| FatalError::from(e).into())
+            },
+            ident,
         )
+    }
+}
+
+impl BlockProof {
+    fn block_ident(p: &GeneratedAggProof) -> String {
+        let b_height = p.p_vals.block_metadata.block_number;
+        let b_range = aggregated_proof_range(p);
+
+        format!(
+            "Block b{} ({}..={})",
+            b_height,
+            *b_range.start(),
+            *b_range.end()
+        )
+    }
+}
+
+fn proof_range_from_aggregatable_proof(p: &AggregatableProof) -> RangeInclusive<usize> {
+    match p {
+        AggregatableProof::Txn(info) => {
+            let txn_idx = info.p_vals.extra_block_data.txn_number_before.as_usize();
+            txn_idx..=txn_idx
+        }
+        AggregatableProof::Agg(info) => aggregated_proof_range(info),
+    }
+}
+
+fn aggregated_proof_range(p: &GeneratedAggProof) -> RangeInclusive<usize> {
+    p.p_vals.extra_block_data.txn_number_before.as_usize()
+        ..=p.p_vals.extra_block_data.txn_number_after.as_usize()
+}
+
+fn b_height_from_aggregatable_proof(p: &AggregatableProof) -> BlockHeight {
+    match p {
+        AggregatableProof::Txn(info) => info.p_vals.block_metadata.block_number.as_u64(),
+        AggregatableProof::Agg(info) => info.p_vals.block_metadata.block_number.as_u64(),
     }
 }


### PR DESCRIPTION
Added proof gen time log entries for all proofs.

I put in a good effort to minimize code duplication, hence the use of closures and a bit of other complexity.