### PR TITLE
Fixed txn proof logs not rendering correctly

### DIFF
--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 [dependencies]
 paladin-core = { workspace = true }
 serde = { workspace = true }
-evm_arithmetization = { workspace = true, optional = true}
+evm_arithmetization = { workspace = true }
 proof_gen = { workspace = true }
 trace_decoder = { workspace = true }
 tracing = { workspace = true }
@@ -23,4 +23,4 @@ common = { path = "../common" }
 
 [features]
 default = []
-test_only = ["evm_arithmetization"]
+test_only = []

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -28,12 +28,7 @@ where
 
     let proof = f()?;
 
-    event!(
-        Level::INFO,
-        "txn proof {:.4} took {:?}",
-        ident,
-        start.elapsed()
-    );
+    event!(Level::INFO, "txn proof took {:?}", start.elapsed());
     Ok(proof)
 }
 

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use common::prover_state::p_state;
+use evm_arithmetization::GenerationInputs;
 use keccak_hash::keccak;
 use paladin::{
     operation::{FatalError, FatalStrategy, Monoid, Operation, Result},
@@ -19,34 +20,19 @@ registry!();
 #[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct TxProof;
 
-fn run_and_wrap_txn_proof_in_elapsed_span<F, O>(f: F, ident: String) -> Result<O>
-where
-    F: Fn() -> Result<O>,
-{
-    let _span = info_span!("proof generation", ident).entered();
-    let start = Instant::now();
-
-    let proof = f()?;
-
-    event!(Level::INFO, "txn proof took {:?}", start.elapsed());
-    Ok(proof)
-}
-
 #[cfg(not(feature = "test_only"))]
 impl Operation for TxProof {
     type Input = TxnProofGenIR;
     type Output = proof_gen::proof_types::AggregatableProof;
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        let txn_ident = Self::txn_ident(&input);
-
-        let proof = run_and_wrap_txn_proof_in_elapsed_span(
+        let proof = Self::run_and_wrap_txn_proof_in_elapsed_span(
             || {
                 common::prover_state::p_manager()
                     .generate_txn_proof(input.clone())
                     .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate).into())
             },
-            txn_ident,
+            &input,
         )?;
 
         Ok(proof.into())
@@ -59,16 +45,14 @@ impl Operation for TxProof {
     type Output = ();
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-        let txn_ident = Self::txn_ident(&input);
-
-        run_and_wrap_txn_proof_in_elapsed_span(
+        Self::run_and_wrap_txn_proof_in_elapsed_span(
             || {
                 evm_arithmetization::prover::testing::simulate_execution::<proof_gen::types::Field>(
                     input.clone(),
                 )
                 .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate).into())
             },
-            txn_ident,
+            &input,
         )?;
 
         Ok(())
@@ -76,17 +60,33 @@ impl Operation for TxProof {
 }
 
 impl TxProof {
-    fn txn_ident(ir: &TxnProofGenIR) -> String {
+    fn run_and_wrap_txn_proof_in_elapsed_span<F, O>(f: F, ir: &GenerationInputs) -> Result<O>
+    where
+        F: Fn() -> Result<O>,
+    {
+        let id = format!(
+            "b{} - {}",
+            ir.block_metadata.block_number, ir.txn_number_before
+        );
+
+        let _span = info_span!("p_gen", id).entered();
+        let start = Instant::now();
+
+        let proof = f()?;
+
         let txn_hash_str = ir
             .signed_txn
             .as_ref()
             .map(|txn| format!("{:x}", keccak(txn)))
             .unwrap_or_else(|| "Dummy".to_string());
 
-        format!(
-            "b{} - {} ({})",
-            ir.block_metadata.block_number, ir.txn_number_before, txn_hash_str
-        )
+        event!(
+            Level::INFO,
+            "txn proof ({}) took {:?}",
+            txn_hash_str,
+            start.elapsed()
+        );
+        Ok(proof)
     }
 }
 


### PR DESCRIPTION
- Txn ident was being printed twice.
- Only the first `4` chars of the ident were being printed.