### PR TITLE
Enable CPU microarchitectural optimizations in rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ opt-level = 3
 incremental = true
 lto = "fat"
 codegen-units = 1
+
+[build]
+rustflags = ["-C", "target-cpu=native"]


### PR DESCRIPTION
This is a pretty short modification to the root `Cargo.toml`. 

Enables Cargo to compile the code with CPU-specific features like vector extensions (AVX512) and optimized instruction scheduling.